### PR TITLE
Add dummy files for Rust backend and Svelte frontend

### DIFF
--- a/neuralui/package.json
+++ b/neuralui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "neuralui",
+  "version": "1.0.0",
+  "description": "Dummy Svelte5 project setup",
+  "main": "index.js",
+  "scripts": {
+    "dev": "svelte-kit dev",
+    "build": "svelte-kit build",
+    "start": "svelte-kit start"
+  },
+  "dependencies": {
+    "@sveltejs/kit": "next",
+    "svelte": "^3.0.0"
+  },
+  "devDependencies": {
+    "svelte": "^3.0.0"
+  }
+}

--- a/neuralui/src/.gitkeep
+++ b/neuralui/src/.gitkeep
@@ -1,0 +1,1 @@
+# This is a placeholder file to ensure the src directory is tracked by git.

--- a/spine/crates/spine-agent-sdk/Cargo.toml
+++ b/spine/crates/spine-agent-sdk/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-agent-sdk"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-context/Cargo.toml
+++ b/spine/crates/spine-context/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-context"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-core/Cargo.toml
+++ b/spine/crates/spine-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-data/Cargo.toml
+++ b/spine/crates/spine-data/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-data"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-extensions/Cargo.toml
+++ b/spine/crates/spine-extensions/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-extensions"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-llm-router/Cargo.toml
+++ b/spine/crates/spine-llm-router/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-llm-router"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-mcp-macros/Cargo.toml
+++ b/spine/crates/spine-mcp-macros/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-mcp-macros"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-mcp/Cargo.toml
+++ b/spine/crates/spine-mcp/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-mcp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-resources/Cargo.toml
+++ b/spine/crates/spine-resources/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-resources"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-router/Cargo.toml
+++ b/spine/crates/spine-router/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-router"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-runtime/Cargo.toml
+++ b/spine/crates/spine-runtime/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-runtime"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-security/Cargo.toml
+++ b/spine/crates/spine-security/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-security"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-services/Cargo.toml
+++ b/spine/crates/spine-services/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-services"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"

--- a/spine/crates/spine-wasm/Cargo.toml
+++ b/spine/crates/spine-wasm/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spine-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = "1.0"
+thiserror = "1.0"


### PR DESCRIPTION
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jknohr/idxworkspace-rust-svelte/pull/1?shareId=5ac1efec-2c53-490d-bde5-8a3512b47c06).

## Summary by Sourcery

Set up initial project structure for a Rust backend (Spine) and Svelte frontend (NeuralUI)

New Features:
- Created initial Svelte frontend project configuration
- Established foundational Rust backend crate structure

Chores:
- Added package.json for Svelte project
- Created multiple Rust crate configurations with basic dependencies